### PR TITLE
Use env for west update args input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,12 +69,14 @@ runs:
         echo "https://x-access-token:${{ inputs.west-token }}@github.com" >> ~/.git-credentials
 
     - name: West update
+      env:
+        WEST_UPDATE_ARGS: ${{ inputs.west-update-args }}
       working-directory: ${{ inputs.path }}
       shell: bash
       run: |
         pip3 install west
         west init -l .
-        west update ${{ inputs.west-update-args }}
+        west update $WEST_UPDATE_ARGS
 
     - name: Remove git credentials
       if: ${{ inputs.west-token != '' }}


### PR DESCRIPTION
We usually hardcode west update args but adding this just in case someone creates new action which takes west update args from e.g. user input.