### PR TITLE
Change step name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout nrf
+    - name: Checkout repo
       uses: actions/checkout@v4
       with:
         ref: ${{ inputs.git-ref }}


### PR DESCRIPTION
It says nrf now. When / if this action is used from elsewhere it is not correct to say "nrf".